### PR TITLE
fix: health check for AWS Alb and whitelist ALB Domain Name

### DIFF
--- a/docker/sites-enabled/frontend.conf
+++ b/docker/sites-enabled/frontend.conf
@@ -1,7 +1,7 @@
 server_names_hash_bucket_size 128;
 
 server {
-   server_name __DOMAIN__NAME__ localhost 127.0.0.1;
+   server_name __DOMAIN__NAME__ __LB_DNS_NAME__ localhost 127.0.0.1;
    listen 80;
 
    location /api/ {
@@ -12,4 +12,12 @@ server {
    location / {
         proxy_pass http://localhost:4000;
    }
+}
+
+server {
+  listen 80 default_server;
+
+  location /ping {
+    return 200 "pong!";
+  }
 }

--- a/startup.sh
+++ b/startup.sh
@@ -16,6 +16,7 @@ cp /home/env.js /home/private-gpt-ui/build/env.js
 
 cp /etc/nginx/sites-enabled/frontend.conf /home/frontend.conf
 sed -i -e "s#__DOMAIN__NAME__#$DOMAIN_NAME#g" /home/frontend.conf
+sed -i -e "s#__LB_DNS_NAME__#$LB_DNS_NAME#g" /home/frontend.conf
 
 cp /home/frontend.conf /etc/nginx/sites-enabled/frontend.conf
 cp /home/frontend.conf /etc/nginx/sites-available/frontend.conf
@@ -24,6 +25,7 @@ cp /home/frontend.conf /etc/nginx/http.d/frontend.conf
 apk update && apk add bash curl nginx openrc
 openrc ; touch /run/openrc/softlevel && echo 'rc_provide="loopback net"' >> /etc/rc.conf
 
+rm -rf /etc/nginx/http.d/default.conf
 # start nginx
 service nginx start
 


### PR DESCRIPTION
- NGINX has a default block for port 80, which we are removing and replacing with a new block for port 80. This modification is necessary for the ALB health check to function properly. The default NGINX configuration for port 80 returns a 404 error because the internal ALB health check is performed using the private IP
- Whitelist Dynamically ALB Domain Name